### PR TITLE
feat(command): add verbosity levels (-q, -v, -vv)

### DIFF
--- a/WebFiori/Cli/Command.php
+++ b/WebFiori/Cli/Command.php
@@ -346,6 +346,17 @@ abstract class Command {
     public function createProgressBar(int $total = 100): ProgressBar {
         return new ProgressBar($this->getOutputStream(), $total);
     }
+
+    /**
+     * Display a message only when verbosity is DEBUG (-vv).
+     *
+     * @param string $message The message that will be shown.
+     */
+    public function debug(string $message): void {
+        if ($this->getVerbosityLevel() >= Verbosity::DEBUG) {
+            $this->printMsg($message, 'Debug', 'gray');
+        }
+    }
     /**
      * Display a message that represents an error.
      * 
@@ -712,13 +723,15 @@ abstract class Command {
      * Display a message that represents extra information.
      * 
      * The message will be prefixed with the string 'Info:' in 
-     * blue.
+     * blue. Suppressed in quiet mode.
      * 
      * @param string $message The message that will be shown.
      * 
      */
     public function info(string $message): void {
-        $this->printMsg($message, 'Info', 'blue');
+        if ($this->getVerbosityLevel() >= Verbosity::NORMAL) {
+            $this->printMsg($message, 'Info', 'blue');
+        }
     }
     /**
      * Checks if an argument is provided in the CLI or not.
@@ -1256,13 +1269,16 @@ abstract class Command {
     /**
      * Display a message that represents a success status.
      * 
-     * The message will be prefixed with the string "Success:" in green. 
+     * The message will be prefixed with the string "Success:" in green.
+     * Suppressed in quiet mode.
      * 
      * @param string $message The message that will be displayed.
      * 
      */
     public function success(string $message): void {
-        $this->printMsg($message, 'Success', 'light-green');
+        if ($this->getVerbosityLevel() >= Verbosity::NORMAL) {
+            $this->printMsg($message, 'Success', 'light-green');
+        }
     }
 
     /**
@@ -1421,6 +1437,17 @@ abstract class Command {
         }
 
         return $this;
+    }
+
+    /**
+     * Display a message only when verbosity is VERBOSE (-v) or higher.
+     *
+     * @param string $message The message that will be shown.
+     */
+    public function verbose(string $message): void {
+        if ($this->getVerbosityLevel() >= Verbosity::VERBOSE) {
+            $this->printMsg($message, 'Verbose', 'cyan');
+        }
     }
     /**
      * Display a message that represents a warning.
@@ -1604,6 +1631,21 @@ abstract class Command {
     }
 
     /**
+     * Returns the current verbosity level from the Runner, or NORMAL as default.
+     *
+     * @return int One of the Verbosity constants.
+     */
+    private function getVerbosityLevel(): int {
+        $owner = $this->getOwner();
+
+        if ($owner !== null) {
+            return $owner->getVerbosity();
+        }
+
+        return Verbosity::NORMAL;
+    }
+
+    /**
      * Checks if ANSI output is enabled for this command.
      *
      * Uses the Runner's resolved ANSI value if available, falls back to
@@ -1620,6 +1662,7 @@ abstract class Command {
 
         return $this->isArgProvided('--ansi');
     }
+
     private function parseArgsHelper() : bool {
         $options = $this->getArgs();
         $invalidArgsVals = [];

--- a/WebFiori/Cli/Runner.php
+++ b/WebFiori/Cli/Runner.php
@@ -117,6 +117,13 @@ class Runner {
     private $signalHandler;
 
     /**
+     * The current verbosity level.
+     * 
+     * @var int
+     */
+    private $verbosity;
+
+    /**
      * Creates new instance of the class.
      */
     public function __construct() {
@@ -132,6 +139,7 @@ class Runner {
         $this->afterRunPool = [];
         $this->signalHandler = null;
         $this->shutdownRequested = false;
+        $this->verbosity = Verbosity::NORMAL;
 
         // Initialize discovery properties
         $this->commandDiscovery = null;
@@ -146,12 +154,25 @@ class Runner {
             ArgumentOption::OPTIONAL => true,
             ArgumentOption::DESCRIPTION => 'Disable ANSI colored output.'
         ]);
+        $this->addArg('-q', [
+            ArgumentOption::OPTIONAL => true,
+            ArgumentOption::DESCRIPTION => 'Quiet mode. Suppress non-critical output.'
+        ]);
+        $this->addArg('-v', [
+            ArgumentOption::OPTIONAL => true,
+            ArgumentOption::DESCRIPTION => 'Verbose output.'
+        ]);
+        $this->addArg('-vv', [
+            ArgumentOption::OPTIONAL => true,
+            ArgumentOption::DESCRIPTION => 'Debug output (most verbose).'
+        ]);
         $this->setBeforeStart(function (Runner $r) {
             if (count($r->getArgsVector()) == 0) {
                 $r->setArgsVector($_SERVER['argv']);
             }
             $r->checkIsInteractive();
             $r->resolveAnsi();
+            $r->resolveVerbosity();
         });
         $this->register(new HelpCommand(), ['-h']);
         $this->setDefaultCommand('help');
@@ -584,6 +605,15 @@ class Runner {
      */
     public function getSignalHandler(): ?SignalHandler {
         return $this->signalHandler;
+    }
+
+    /**
+     * Returns the current verbosity level.
+     *
+     * @return int One of the Verbosity constants.
+     */
+    public function getVerbosity(): int {
+        return $this->verbosity;
     }
 
     /**
@@ -1096,6 +1126,19 @@ class Runner {
     }
 
     /**
+     * Sets the verbosity level.
+     *
+     * @param int $level One of the Verbosity constants.
+     *
+     * @return Runner The method returns same instance for chaining.
+     */
+    public function setVerbosity(int $level): Runner {
+        $this->verbosity = $level;
+
+        return $this;
+    }
+
+    /**
      * Determines if ANSI output should be used based on environment detection.
      *
      * Resolution precedence:
@@ -1139,7 +1182,7 @@ class Runner {
         if ($this->isInteractive()) {
             if (in_array('--no-color', $this->getArgsVector())) {
                 $this->isAnsi = false;
-            } elseif (in_array('--ansi', $this->getArgsVector())) {
+            } else if (in_array('--ansi', $this->getArgsVector())) {
                 $this->isAnsi = true;
             }
             $this->printMsg('Running in interactive mode.', '>>', 'blue');
@@ -1228,7 +1271,7 @@ class Runner {
 
         $argsArr = strlen($input) != 0 ? explode(' ', $input) : [];
 
-        $argsArr = $this->removeAnsiArgs($argsArr);
+        $argsArr = $this->removeGlobalFlags($argsArr);
 
         // Preprocess help patterns
         $argsArr = $this->preprocessHelpPattern($argsArr);
@@ -1280,30 +1323,6 @@ class Runner {
             }
         }
     }
-    /**
-     * Removes --ansi and --no-color flags from an arguments array.
-     *
-     * @param array $argsArr The arguments array.
-     *
-     * @return array The filtered arguments array.
-     */
-    private function removeAnsiArgs(array $argsArr): array {
-        $tempArgs = [];
-
-        foreach ($argsArr as $argName => $val) {
-            if (gettype($argName) == 'integer') {
-                if ($val != '--ansi' && $val != '--no-color') {
-                    $tempArgs[] = $val;
-                }
-            } else {
-                if ($argName != '--ansi' && $argName != '--no-color') {
-                    $tempArgs[$argName] = $val;
-                }
-            }
-        }
-
-        return $tempArgs;
-    }
 
     private function removeCommandSignalHandlers(Command $c): void {
         if ($this->signalHandler !== null) {
@@ -1313,10 +1332,47 @@ class Runner {
             $c->clearSignalHandlers();
         }
     }
+    /**
+     * Removes --ansi and --no-color flags from an arguments array.
+     *
+     * @param array $argsArr The arguments array.
+     *
+     * @return array The filtered arguments array.
+     */
+    private function removeGlobalFlags(array $argsArr): array {
+        $flags = ['--ansi', '--no-color', '-q', '-v', '-vv'];
+        $tempArgs = [];
+
+        foreach ($argsArr as $argName => $val) {
+            if (gettype($argName) == 'integer') {
+                if (!in_array($val, $flags)) {
+                    $tempArgs[] = $val;
+                }
+            } else {
+                if (!in_array($argName, $flags)) {
+                    $tempArgs[$argName] = $val;
+                }
+            }
+        }
+
+        return $tempArgs;
+    }
 
     private function resolveAnsi(): void {
         if ($this->outputStream instanceof StdOut) {
             $this->isAnsi = self::shouldUseAnsi();
+        }
+    }
+
+    private function resolveVerbosity(): void {
+        $args = $this->getArgsVector();
+
+        if (in_array('-vv', $args)) {
+            $this->verbosity = Verbosity::DEBUG;
+        } else if (in_array('-v', $args)) {
+            $this->verbosity = Verbosity::VERBOSE;
+        } else if (in_array('-q', $args)) {
+            $this->verbosity = Verbosity::QUIET;
         }
     }
 
@@ -1330,11 +1386,11 @@ class Runner {
 
         if (in_array('--no-color', $argsArr)) {
             $this->isAnsi = false;
-        } elseif (in_array('--ansi', $argsArr)) {
+        } else if (in_array('--ansi', $argsArr)) {
             $this->isAnsi = true;
         }
 
-        $argsArr = $this->removeAnsiArgs($argsArr);
+        $argsArr = $this->removeGlobalFlags($argsArr);
 
         // Preprocess help patterns for non-interactive mode
         $argsArr = $this->preprocessHelpPattern($argsArr);

--- a/WebFiori/Cli/Verbosity.php
+++ b/WebFiori/Cli/Verbosity.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+namespace WebFiori\Cli;
+
+/**
+ * Constants that define the verbosity levels for CLI output.
+ *
+ * @author Ibrahim
+ */
+class Verbosity {
+    /**
+     * Debug mode - maximum output detail.
+     */
+    const DEBUG = 3;
+    /**
+     * Normal mode - default output level.
+     */
+    const NORMAL = 1;
+    /**
+     * Quiet mode - only errors and warnings are shown.
+     */
+    const QUIET = 0;
+    /**
+     * Verbose mode - additional diagnostic information.
+     */
+    const VERBOSE = 2;
+}

--- a/tests/WebFiori/Tests/Cli/RunnerTest.php
+++ b/tests/WebFiori/Tests/Cli/RunnerTest.php
@@ -60,9 +60,9 @@ class RunnerTest extends CommandTestCase {
         $this->assertTrue($runner->addArg('global-arg', [
             ArgumentOption::OPTIONAL => true
         ]));
-        $this->assertEquals(3, count($runner->getArgs()));
+        $this->assertEquals(6, count($runner->getArgs()));
         $runner->removeArgument('--ansi');
-        $this->assertEquals(2, count($runner->getArgs()));
+        $this->assertEquals(5, count($runner->getArgs()));
         $this->assertFalse($runner->hasArg('--ansi'));
         $runner->register(new Command00());
         $this->assertEquals(2, count($runner->getCommands())); // help + super-hero
@@ -151,6 +151,9 @@ class RunnerTest extends CommandTestCase {
         // Don't register HelpCommand again - it's already automatically registered
         $runner->removeArgument('--ansi');
         $runner->removeArgument('--no-color');
+        $runner->removeArgument('-q');
+        $runner->removeArgument('-v');
+        $runner->removeArgument('-vv');
         $runner->setDefaultCommand('help');
         $runner->setInputs([]);
         $this->assertEquals(0, $runner->runCommand(null, []));
@@ -174,6 +177,9 @@ class RunnerTest extends CommandTestCase {
             "Global Arguments:\n",
             "    --ansi:[Optional] Force the use of ANSI output.\n",
             "    --no-color:[Optional] Disable ANSI colored output.\n",
+            "      -q:[Optional] Quiet mode. Suppress non-critical output.\n",
+            "      -v:[Optional] Verbose output.\n",
+            "     -vv:[Optional] Debug output (most verbose).\n",
             "Available Commands:\n",
             "    help:           Display CLI Help. To display help for specific command, use the argument \"--command\" with this command.\n",
             "    super-hero:     A command to display hero's name.\n"
@@ -201,6 +207,9 @@ class RunnerTest extends CommandTestCase {
             "\e[1;93mGlobal Arguments:\e[0m\n",
             "\e[1;33m    --ansi:\e[0m[Optional] Force the use of ANSI output.\n",
             "\e[1;33m    --no-color:\e[0m[Optional] Disable ANSI colored output.\n",
+            "\e[1;33m      -q:\e[0m[Optional] Quiet mode. Suppress non-critical output.\n",
+            "\e[1;33m      -v:\e[0m[Optional] Verbose output.\n",
+            "\e[1;33m     -vv:\e[0m[Optional] Debug output (most verbose).\n",
             "\e[1;93mAvailable Commands:\e[0m\n",
             "\e[1;33m    help\e[0m:           Display CLI Help. To display help for specific command, use the argument \"--command\" with this command.\n",
             "\e[1;33m    super-hero\e[0m:     A command to display hero's name.\n"
@@ -231,6 +240,9 @@ class RunnerTest extends CommandTestCase {
         $runner = new Runner();
         $runner->removeArgument('--ansi');
         $runner->removeArgument('--no-color');
+        $runner->removeArgument('-q');
+        $runner->removeArgument('-v');
+        $runner->removeArgument('-vv');
         $runner->register(new Command00());
         // Don't register HelpCommand - it's automatically registered
         $runner->setDefaultCommand('help');
@@ -337,6 +349,9 @@ class RunnerTest extends CommandTestCase {
             "Global Arguments:\n",
             "    --ansi:[Optional] Force the use of ANSI output.\n",
             "    --no-color:[Optional] Disable ANSI colored output.\n",
+            "      -q:[Optional] Quiet mode. Suppress non-critical output.\n",
+            "      -v:[Optional] Verbose output.\n",
+            "     -vv:[Optional] Debug output (most verbose).\n",
             "Available Commands:\n",
             "    help:           Display CLI Help. To display help for specific command, use the argument \"--command\" with this command.\n",
             "    super-hero:     A command to display hero's name.\n",

--- a/tests/WebFiori/Tests/Cli/VerbosityTest.php
+++ b/tests/WebFiori/Tests/Cli/VerbosityTest.php
@@ -1,0 +1,258 @@
+<?php
+declare(strict_types=1);
+
+namespace WebFiori\Tests\Cli;
+
+use WebFiori\Cli\Command;
+use WebFiori\Cli\CommandTestCase;
+use WebFiori\Cli\Runner;
+use WebFiori\Cli\Verbosity;
+
+class VerbosityTestCommand extends Command {
+    public function __construct() {
+        parent::__construct('verb-test', [], 'Test verbosity levels');
+    }
+
+    public function exec(): int {
+        $this->error('error msg');
+        $this->warning('warning msg');
+        $this->info('info msg');
+        $this->success('success msg');
+        $this->verbose('verbose msg');
+        $this->debug('debug msg');
+        $this->println('always shown');
+
+        return 0;
+    }
+}
+
+class VerbosityTest extends CommandTestCase {
+    /**
+     * @test
+     */
+    public function testVerbosityConstants() {
+        $this->assertEquals(0, Verbosity::QUIET);
+        $this->assertEquals(1, Verbosity::NORMAL);
+        $this->assertEquals(2, Verbosity::VERBOSE);
+        $this->assertEquals(3, Verbosity::DEBUG);
+    }
+
+    /**
+     * @test
+     */
+    public function testDefaultVerbosityIsNormal() {
+        $runner = new Runner();
+        $runner->reset();
+        $this->assertEquals(Verbosity::NORMAL, $runner->getVerbosity());
+    }
+
+    /**
+     * @test
+     */
+    public function testSetVerbosity() {
+        $runner = new Runner();
+        $runner->reset();
+
+        $result = $runner->setVerbosity(Verbosity::QUIET);
+        $this->assertSame($runner, $result);
+        $this->assertEquals(Verbosity::QUIET, $runner->getVerbosity());
+
+        $runner->setVerbosity(Verbosity::VERBOSE);
+        $this->assertEquals(Verbosity::VERBOSE, $runner->getVerbosity());
+
+        $runner->setVerbosity(Verbosity::DEBUG);
+        $this->assertEquals(Verbosity::DEBUG, $runner->getVerbosity());
+    }
+
+    /**
+     * @test
+     */
+    public function testQuietModeViaFlag() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new VerbosityTestCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'verb-test', '-q']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        // error and warning always shown
+        $this->assertStringContainsString('error msg', $outputStr);
+        $this->assertStringContainsString('warning msg', $outputStr);
+        // println always shown
+        $this->assertStringContainsString('always shown', $outputStr);
+        // info and success suppressed
+        $this->assertStringNotContainsString('info msg', $outputStr);
+        $this->assertStringNotContainsString('success msg', $outputStr);
+        // verbose and debug suppressed
+        $this->assertStringNotContainsString('verbose msg', $outputStr);
+        $this->assertStringNotContainsString('debug msg', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testNormalMode() {
+        $output = $this->executeSingleCommand(new VerbosityTestCommand());
+        $outputStr = implode('', $output);
+
+        // error, warning, info, success shown
+        $this->assertStringContainsString('error msg', $outputStr);
+        $this->assertStringContainsString('warning msg', $outputStr);
+        $this->assertStringContainsString('info msg', $outputStr);
+        $this->assertStringContainsString('success msg', $outputStr);
+        $this->assertStringContainsString('always shown', $outputStr);
+        // verbose and debug suppressed
+        $this->assertStringNotContainsString('verbose msg', $outputStr);
+        $this->assertStringNotContainsString('debug msg', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testVerboseModeViaFlag() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new VerbosityTestCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'verb-test', '-v']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        // everything except debug shown
+        $this->assertStringContainsString('error msg', $outputStr);
+        $this->assertStringContainsString('warning msg', $outputStr);
+        $this->assertStringContainsString('info msg', $outputStr);
+        $this->assertStringContainsString('success msg', $outputStr);
+        $this->assertStringContainsString('verbose msg', $outputStr);
+        $this->assertStringContainsString('always shown', $outputStr);
+        // debug suppressed
+        $this->assertStringNotContainsString('debug msg', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testDebugModeViaFlag() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new VerbosityTestCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'verb-test', '-vv']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        // everything shown
+        $this->assertStringContainsString('error msg', $outputStr);
+        $this->assertStringContainsString('warning msg', $outputStr);
+        $this->assertStringContainsString('info msg', $outputStr);
+        $this->assertStringContainsString('success msg', $outputStr);
+        $this->assertStringContainsString('verbose msg', $outputStr);
+        $this->assertStringContainsString('debug msg', $outputStr);
+        $this->assertStringContainsString('always shown', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testSetVerbosityProgrammatically() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->setVerbosity(Verbosity::QUIET);
+        $runner->register(new VerbosityTestCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'verb-test']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        $this->assertStringContainsString('error msg', $outputStr);
+        $this->assertStringNotContainsString('info msg', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testFlagOverridesProgrammaticVerbosity() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->setVerbosity(Verbosity::QUIET);
+        $runner->register(new VerbosityTestCommand());
+        $runner->setInputs([]);
+        // -vv flag should override the programmatic QUIET setting
+        $runner->setArgsVector(['main.php', 'verb-test', '-vv']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        $this->assertStringContainsString('debug msg', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testVerbosityFlagsStrippedFromArgs() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new VerbosityTestCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'verb-test', '-v']);
+        $runner->start();
+
+        // Command should execute successfully (flag not passed as unknown arg)
+        $this->assertEquals(0, $runner->getLastCommandExitStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function testQuietFlagStrippedFromArgs() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new VerbosityTestCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'verb-test', '-q']);
+        $runner->start();
+
+        $this->assertEquals(0, $runner->getLastCommandExitStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function testCommandWithoutOwnerDefaultsToNormal() {
+        // Command without Runner uses NORMAL verbosity
+        $command = new VerbosityTestCommand();
+        $output = $this->executeSingleCommand($command);
+        $outputStr = implode('', $output);
+
+        $this->assertStringContainsString('info msg', $outputStr);
+        $this->assertStringNotContainsString('verbose msg', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testInteractiveModeWithQuiet() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new VerbosityTestCommand());
+        $runner->setArgsVector(['main.php', '-i', '-q']);
+        $runner->setInputs(['verb-test', 'exit']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        $this->assertStringContainsString('error msg', $outputStr);
+        $this->assertStringNotContainsString('info msg', $outputStr);
+    }
+}


### PR DESCRIPTION
# Summary
Add verbosity levels to control CLI output detail, following Unix CLI conventions.

## Motivation
No way to suppress non-critical output in automated/cron contexts or show extra diagnostics when debugging. Closes #46.

## Changes
- Added `Verbosity` class with `QUIET(0)`, `NORMAL(1)`, `VERBOSE(2)`, `DEBUG(3)` constants
- Added `-q`, `-v`, `-vv` global arguments to Runner
- Added `getVerbosity()` and `setVerbosity()` to Runner
- Added `verbose(string $msg)` method to Command (shown at `-v` or higher)
- Added `debug(string $msg)` method to Command (shown at `-vv` only)
- Gated `info()` and `success()` — suppressed in quiet mode (`-q`)
- `error()` and `warning()` always shown regardless of verbosity
- `println()` and `prints()` unchanged (unconditional low-level primitives)
- Verbosity flags stripped from args passed to commands
- Renamed `removeAnsiArgs` → `removeGlobalFlags` (handles all global flags)

## How to Test / Verify
- `tests/WebFiori/Tests/Cli/VerbosityTest.php` (13 tests, 46 assertions)
- Updated `RunnerTest.php` for new global args in help output

Run: `composer test`

## Breaking Changes and Migration Steps
None. Default verbosity is NORMAL — all existing behavior preserved.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [ ] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs)
- [x] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #46