### PR TITLE
feat(command): add #[Group] and #[SingleInstance] attributes

### DIFF
--- a/WebFiori/Cli/Attributes/Group.php
+++ b/WebFiori/Cli/Attributes/Group.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+namespace WebFiori\Cli\Attributes;
+
+use Attribute;
+
+/**
+ * Attribute to assign a command to a named group for help display organization.
+ *
+ * @author Ibrahim
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class Group {
+    public readonly string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+}

--- a/WebFiori/Cli/Attributes/SingleInstance.php
+++ b/WebFiori/Cli/Attributes/SingleInstance.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+namespace WebFiori\Cli\Attributes;
+
+use Attribute;
+
+/**
+ * Attribute to prevent concurrent execution of a command.
+ *
+ * When applied to a command class, only one instance of the command
+ * can run at a time. Subsequent attempts will fail with a warning.
+ *
+ * @author Ibrahim
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class SingleInstance {
+    public readonly int $exitCode;
+    public readonly ?string $lockPath;
+
+    public function __construct(?string $lockPath = null, int $exitCode = 1) {
+        $this->lockPath = $lockPath;
+        $this->exitCode = $exitCode;
+    }
+}

--- a/WebFiori/Cli/Command.php
+++ b/WebFiori/Cli/Command.php
@@ -46,6 +46,11 @@ abstract class Command {
      */
     private $description;
     /**
+     * The group this command belongs to for help display.
+     * @var string|null
+     */
+    private $group;
+    /**
      * 
      * @var InputStream
      * 
@@ -99,6 +104,7 @@ abstract class Command {
         }
         $this->aliases = $aliases;
         $this->signalHandlers = [];
+        $this->group = null;
         $this->addArgs($args);
 
         if (!$this->setDescription($description)) {
@@ -381,6 +387,7 @@ abstract class Command {
      */
     public function excCommand() : int {
         $retVal = -1;
+        $lockManager = null;
 
         $runner = $this->getOwner();
 
@@ -390,20 +397,45 @@ abstract class Command {
             }
         }
 
-        if ($this->parseArgsHelper()) {
-            // Check for help first, before validating required arguments
-            if ($this->isArgProvided('help') || $this->isArgProvided('-h')) {
-                $help = $runner->getCommandByName('help');
-                $help->setArgValue('--command', $this->getName());
-                $help->setOwner($runner);
-                $help->setOutputStream($runner->getOutputStream());
-                $this->removeArgument('help');
+        // Check for SingleInstance attribute
+        $singleInstance = $this->resolveSingleInstance();
 
-                return $help->exec();
-            } else if ($this->checkIsArgsSetHelper()) {
-                $retVal = $this->exec();
+        if ($singleInstance !== null) {
+            $lockManager = new LockManager();
+
+            if (!$lockManager->acquire($this->getName(), $singleInstance->lockPath)) {
+                $this->warning('Command is already running.');
+
+                if ($runner !== null) {
+                    foreach ($runner->getArgs() as $arg) {
+                        $this->removeArgument($arg->getName());
+                        $arg->resetValue();
+                    }
+                }
+
+                return $singleInstance->exitCode;
             }
+        }
 
+        try {
+            if ($this->parseArgsHelper()) {
+                // Check for help first, before validating required arguments
+                if ($this->isArgProvided('help') || $this->isArgProvided('-h')) {
+                    $help = $runner->getCommandByName('help');
+                    $help->setArgValue('--command', $this->getName());
+                    $help->setOwner($runner);
+                    $help->setOutputStream($runner->getOutputStream());
+                    $this->removeArgument('help');
+
+                    $retVal = $help->exec();
+                } else if ($this->checkIsArgsSetHelper()) {
+                    $retVal = $this->exec();
+                }
+            }
+        } finally {
+            if ($lockManager !== null) {
+                $lockManager->release();
+            }
         }
 
         if ($runner !== null) {
@@ -544,6 +576,15 @@ abstract class Command {
      */
     public function getDescription() : string {
         return $this->description;
+    }
+
+    /**
+     * Returns the group this command belongs to.
+     *
+     * @return string|null The group name, or null if ungrouped.
+     */
+    public function getGroup(): ?string {
+        return $this->group;
     }
 
     /**
@@ -1101,6 +1142,32 @@ abstract class Command {
     }
 
     /**
+     * Resolves the group for this command from attributes or name convention.
+     *
+     * Priority: 1. Explicit setGroup() 2. #[Group] attribute 3. Colon prefix in name
+     */
+    public function resolveGroup(): void {
+        if ($this->group !== null) {
+            return;
+        }
+
+        $ref = new ReflectionClass($this);
+        $attrs = $ref->getAttributes(Attributes\Group::class);
+
+        if (count($attrs) > 0) {
+            $this->group = $attrs[0]->newInstance()->name;
+
+            return;
+        }
+
+        $colonPos = strpos($this->getName(), ':');
+
+        if ($colonPos !== false) {
+            $this->group = substr($this->getName(), 0, $colonPos);
+        }
+    }
+
+    /**
      * Ask the user to select one of multiple values.
      * 
      * This method will display a prompt and wait for the user to select 
@@ -1213,6 +1280,15 @@ abstract class Command {
         }
 
         return false;
+    }
+
+    /**
+     * Sets the group this command belongs to for help display organization.
+     *
+     * @param string $group The group name.
+     */
+    public function setGroup(string $group): void {
+        $this->group = $group;
     }
     /**
      * Sets the stream at which the command will read input from.
@@ -1781,5 +1857,21 @@ abstract class Command {
         $this->println();
 
         return $input;
+    }
+
+    /**
+     * Resolves the SingleInstance attribute on this command class.
+     *
+     * @return Attributes\SingleInstance|null The attribute instance, or null if not present.
+     */
+    private function resolveSingleInstance(): ?Attributes\SingleInstance {
+        $ref = new ReflectionClass($this);
+        $attrs = $ref->getAttributes(Attributes\SingleInstance::class);
+
+        if (count($attrs) > 0) {
+            return $attrs[0]->newInstance();
+        }
+
+        return null;
     }
 }

--- a/WebFiori/Cli/Commands/HelpCommand.php
+++ b/WebFiori/Cli/Commands/HelpCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 namespace WebFiori\Cli\Commands;
 
@@ -59,9 +60,7 @@ class HelpCommand extends Command {
             $this->printGlobalArgs($formattingOptions);
             $this->println("Available Commands:", $formattingOptions);
 
-            foreach ($regCommands as $commandObj) {
-                $this->printCommandInfo($commandObj, $len);
-            }
+            $this->printCommandsGrouped($regCommands, $len, $formattingOptions);
         }
 
         return 0;
@@ -98,15 +97,16 @@ class HelpCommand extends Command {
 
     private function printArgsTable(array $args) {
         $rows = [];
+
         foreach ($args as $argObj) {
             $name = $argObj->getName();
             $required = $argObj->isOptional() ? 'No' : 'Yes';
             $default = $argObj->getDefault() ?: '-';
             $description = $argObj->getDescription() ?: '<NO DESCRIPTION>';
-            
+
             $rows[] = [$name, $required, $default, $description];
         }
-        
+
         $this->table($rows, ['Argument', 'Required', 'Default', 'Description']);
     }
 
@@ -129,7 +129,7 @@ class HelpCommand extends Command {
         $this->println(str_repeat(' ', $spacesCount)."%s", $cliCommand->getDescription());
 
         if ($withArgs) {
-            $args = array_filter($cliCommand->getArgs(), function($arg) {
+            $args = array_filter($cliCommand->getArgs(), function ($arg) {
                 return !in_array($arg->getName(), ['help', '-h']);
             });
 
@@ -146,6 +146,51 @@ class HelpCommand extends Command {
                         $this->printArg($argObj);
                     }
                 }
+            }
+        }
+    }
+
+    private function printCommandsGrouped(array $commands, int $len, array $formattingOptions) {
+        $grouped = [];
+        $ungrouped = [];
+
+        foreach ($commands as $commandObj) {
+            $group = $commandObj->getGroup();
+
+            if ($group !== null) {
+                $grouped[$group][] = $commandObj;
+            } else {
+                $ungrouped[] = $commandObj;
+            }
+        }
+
+        if (count($grouped) == 0) {
+            // No groups — flat list
+            foreach ($ungrouped as $commandObj) {
+                $this->printCommandInfo($commandObj, $len);
+            }
+
+            return;
+        }
+
+        // Print grouped commands first
+        ksort($grouped);
+
+        foreach ($grouped as $groupName => $groupCommands) {
+            $this->println("  %s:", $groupName, [
+                'bold' => true,
+                'color' => 'light-blue'
+            ]);
+
+            foreach ($groupCommands as $commandObj) {
+                $this->printCommandInfo($commandObj, $len);
+            }
+        }
+
+        // Print ungrouped commands
+        if (count($ungrouped) > 0) {
+            foreach ($ungrouped as $commandObj) {
+                $this->printCommandInfo($commandObj, $len);
             }
         }
     }

--- a/WebFiori/Cli/LockManager.php
+++ b/WebFiori/Cli/LockManager.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+namespace WebFiori\Cli;
+
+/**
+ * Manages file-based locks for single-instance command execution.
+ *
+ * Uses flock() for non-blocking exclusive locks. The lock is automatically
+ * released when the file handle is closed (including on process crash).
+ *
+ * @author Ibrahim
+ */
+class LockManager {
+    /**
+     * @var resource|null
+     */
+    private $handle;
+
+    /**
+     * @var string|null
+     */
+    private $lockPath;
+
+    public function __construct() {
+        $this->handle = null;
+        $this->lockPath = null;
+    }
+
+    /**
+     * Attempts to acquire an exclusive non-blocking lock.
+     *
+     * @param string $commandName The command name used to generate the lock file path.
+     *
+     * @param string|null $customPath Optional custom lock file path.
+     *
+     * @return bool True if the lock was acquired, false otherwise.
+     */
+    public function acquire(string $commandName, ?string $customPath = null): bool {
+        $this->lockPath = $customPath ?? sys_get_temp_dir().'/wfcli-'.$commandName.'.lock';
+
+        $handle = @fopen($this->lockPath, 'w');
+
+        if ($handle === false) {
+            return false;
+        }
+
+        if (!flock($handle, LOCK_EX | LOCK_NB)) {
+            fclose($handle);
+
+            return false;
+        }
+
+        $this->handle = $handle;
+        fwrite($this->handle, (string) getmypid());
+        fflush($this->handle);
+
+        return true;
+    }
+
+    /**
+     * Returns the lock file path.
+     *
+     * @return string|null The path, or null if no lock has been attempted.
+     */
+    public function getLockPath(): ?string {
+        return $this->lockPath;
+    }
+
+    /**
+     * Checks if the lock is currently held.
+     *
+     * @return bool True if a lock is held.
+     */
+    public function isLocked(): bool {
+        return $this->handle !== null;
+    }
+
+    /**
+     * Releases the lock and closes the file handle.
+     */
+    public function release(): void {
+        if ($this->handle !== null) {
+            flock($this->handle, LOCK_UN);
+            fclose($this->handle);
+            $this->handle = null;
+        }
+
+        if ($this->lockPath !== null && file_exists($this->lockPath)) {
+            @unlink($this->lockPath);
+            $this->lockPath = null;
+        }
+    }
+}

--- a/WebFiori/Cli/Runner.php
+++ b/WebFiori/Cli/Runner.php
@@ -729,6 +729,9 @@ class Runner {
         }
         $this->commands[$cliCommand->getName()] = $cliCommand;
 
+        // Resolve group from attribute or name convention
+        $cliCommand->resolveGroup();
+
         // Register runtime aliases
         foreach ($aliases as $alias) {
             $this->registerAlias($alias, $cliCommand->getName());

--- a/tests/WebFiori/Tests/Cli/CommandAttributesTest.php
+++ b/tests/WebFiori/Tests/Cli/CommandAttributesTest.php
@@ -1,0 +1,242 @@
+<?php
+declare(strict_types=1);
+
+namespace WebFiori\Tests\Cli;
+
+use WebFiori\Cli\Attributes\Group;
+use WebFiori\Cli\Attributes\SingleInstance;
+use WebFiori\Cli\Command;
+use WebFiori\Cli\CommandTestCase;
+use WebFiori\Cli\Runner;
+
+#[SingleInstance]
+class SingleInstanceCommand extends Command {
+    public function __construct() {
+        parent::__construct('locked-cmd', [], 'A single-instance command');
+    }
+
+    public function exec(): int {
+        $this->println('running');
+
+        return 0;
+    }
+}
+
+#[SingleInstance(lockPath: null, exitCode: 42)]
+class SingleInstanceCustomExitCommand extends Command {
+    public function __construct() {
+        parent::__construct('locked-custom', [], 'Custom exit code');
+    }
+
+    public function exec(): int {
+        $this->println('running');
+
+        return 0;
+    }
+}
+
+#[Group('db')]
+class DbMigrateCommand extends Command {
+    public function __construct() {
+        parent::__construct('db:migrate', [], 'Run database migrations');
+    }
+
+    public function exec(): int {
+        $this->println('migrating');
+
+        return 0;
+    }
+}
+
+#[Group('db')]
+class DbSeedCommand extends Command {
+    public function __construct() {
+        parent::__construct('db:seed', [], 'Seed the database');
+    }
+
+    public function exec(): int {
+        return 0;
+    }
+}
+
+class UngroupedCommand extends Command {
+    public function __construct() {
+        parent::__construct('serve', [], 'Start dev server');
+    }
+
+    public function exec(): int {
+        return 0;
+    }
+}
+
+class ColonGroupCommand extends Command {
+    public function __construct() {
+        parent::__construct('cache:clear', [], 'Clear the cache');
+    }
+
+    public function exec(): int {
+        return 0;
+    }
+}
+
+class CommandAttributesTest extends CommandTestCase {
+    /**
+     * @test
+     */
+    public function testSingleInstanceRunsNormally() {
+        $output = $this->executeSingleCommand(new SingleInstanceCommand());
+        $this->assertContains("running\n", $output);
+        $this->assertEquals(0, $this->getExitCode());
+    }
+
+    /**
+     * @test
+     */
+    public function testSingleInstanceBlocksConcurrent() {
+        // Acquire lock manually, then try to run the command
+        $lm = new \WebFiori\Cli\LockManager();
+        $this->assertTrue($lm->acquire('locked-cmd'));
+
+        $output = $this->executeSingleCommand(new SingleInstanceCommand());
+        $outputStr = implode('', $output);
+
+        $this->assertStringContainsString('already running', $outputStr);
+        $this->assertEquals(1, $this->getExitCode());
+
+        $lm->release();
+    }
+
+    /**
+     * @test
+     */
+    public function testSingleInstanceCustomExitCode() {
+        $lm = new \WebFiori\Cli\LockManager();
+        $this->assertTrue($lm->acquire('locked-custom'));
+
+        $this->executeSingleCommand(new SingleInstanceCustomExitCommand());
+        $this->assertEquals(42, $this->getExitCode());
+
+        $lm->release();
+    }
+
+    /**
+     * @test
+     */
+    public function testSingleInstanceReleasesLockAfterExec() {
+        $this->executeSingleCommand(new SingleInstanceCommand());
+
+        // Lock should be released — can acquire again
+        $lm = new \WebFiori\Cli\LockManager();
+        $this->assertTrue($lm->acquire('locked-cmd'));
+        $lm->release();
+    }
+
+    /**
+     * @test
+     */
+    public function testGroupAttributeResolved() {
+        $cmd = new DbMigrateCommand();
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register($cmd);
+
+        $this->assertEquals('db', $cmd->getGroup());
+    }
+
+    /**
+     * @test
+     */
+    public function testGroupFromColonConvention() {
+        $cmd = new ColonGroupCommand();
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register($cmd);
+
+        $this->assertEquals('cache', $cmd->getGroup());
+    }
+
+    /**
+     * @test
+     */
+    public function testExplicitGroupOverridesAttribute() {
+        $cmd = new DbMigrateCommand();
+        $cmd->setGroup('custom');
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register($cmd);
+
+        // Explicit setGroup should win
+        $this->assertEquals('custom', $cmd->getGroup());
+    }
+
+    /**
+     * @test
+     */
+    public function testUngroupedCommandHasNullGroup() {
+        $cmd = new UngroupedCommand();
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register($cmd);
+
+        $this->assertNull($cmd->getGroup());
+    }
+
+    /**
+     * @test
+     */
+    public function testHelpOutputGrouped() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new DbMigrateCommand());
+        $runner->register(new DbSeedCommand());
+        $runner->register(new UngroupedCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'help']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        // Should show group header
+        $this->assertStringContainsString('db:', $outputStr);
+        // Should contain commands
+        $this->assertStringContainsString('db:migrate', $outputStr);
+        $this->assertStringContainsString('db:seed', $outputStr);
+        $this->assertStringContainsString('serve', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testHelpOutputNoGroupsFlatList() {
+        $runner = new Runner();
+        $runner->reset();
+        $runner->register(new UngroupedCommand());
+        $runner->setInputs([]);
+        $runner->setArgsVector(['main.php', 'help']);
+        $runner->start();
+
+        $output = $runner->getOutput();
+        $outputStr = implode('', $output);
+
+        // No group headers for ungrouped-only output
+        $this->assertStringContainsString('serve', $outputStr);
+    }
+
+    /**
+     * @test
+     */
+    public function testGetGroupDefaultNull() {
+        $cmd = new UngroupedCommand();
+        $this->assertNull($cmd->getGroup());
+    }
+
+    /**
+     * @test
+     */
+    public function testSetGroup() {
+        $cmd = new UngroupedCommand();
+        $cmd->setGroup('mygroup');
+        $this->assertEquals('mygroup', $cmd->getGroup());
+    }
+}

--- a/tests/WebFiori/Tests/Cli/LockManagerTest.php
+++ b/tests/WebFiori/Tests/Cli/LockManagerTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace WebFiori\Tests\Cli;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Cli\LockManager;
+
+class LockManagerTest extends TestCase {
+    /**
+     * @test
+     */
+    public function testInitialState() {
+        $lm = new LockManager();
+        $this->assertFalse($lm->isLocked());
+        $this->assertNull($lm->getLockPath());
+    }
+
+    /**
+     * @test
+     */
+    public function testAcquireAndRelease() {
+        $lm = new LockManager();
+        $this->assertTrue($lm->acquire('test-cmd'));
+        $this->assertTrue($lm->isLocked());
+        $this->assertNotNull($lm->getLockPath());
+        $this->assertStringContainsString('wfcli-test-cmd.lock', $lm->getLockPath());
+
+        $lm->release();
+        $this->assertFalse($lm->isLocked());
+    }
+
+    /**
+     * @test
+     */
+    public function testCustomLockPath() {
+        $path = sys_get_temp_dir() . '/custom-test-lock.lock';
+        $lm = new LockManager();
+        $this->assertTrue($lm->acquire('ignored', $path));
+        $this->assertEquals($path, $lm->getLockPath());
+
+        $lm->release();
+    }
+
+    /**
+     * @test
+     */
+    public function testConcurrentAcquireFails() {
+        $lm1 = new LockManager();
+        $lm2 = new LockManager();
+
+        $this->assertTrue($lm1->acquire('concurrent-test'));
+        $this->assertFalse($lm2->acquire('concurrent-test'));
+
+        $lm1->release();
+
+        // Now second can acquire
+        $this->assertTrue($lm2->acquire('concurrent-test'));
+        $lm2->release();
+    }
+
+    /**
+     * @test
+     */
+    public function testReleaseWithoutAcquire() {
+        $lm = new LockManager();
+        // Should not throw
+        $lm->release();
+        $this->assertFalse($lm->isLocked());
+    }
+
+    /**
+     * @test
+     */
+    public function testLockFileContainsPid() {
+        $lm = new LockManager();
+        $lm->acquire('pid-test');
+        $path = $lm->getLockPath();
+        $content = file_get_contents($path);
+        $this->assertEquals((string) getmypid(), $content);
+
+        $lm->release();
+    }
+
+    /**
+     * @test
+     */
+    public function testAcquireFailsOnInvalidPath() {
+        $lm = new LockManager();
+        $result = $lm->acquire('test', '/nonexistent/dir/lock.lock');
+        $this->assertFalse($result);
+        $this->assertFalse($lm->isLocked());
+    }
+}


### PR DESCRIPTION
# Summary
Introduce PHP 8.1 attributes for command metadata, establishing the `WebFiori\Cli\Attributes\` namespace per ADR-0025.

## Motivation
- **#47**: Help output is a flat list — hard to scan with 20+ commands
- **#49**: No built-in mechanism to prevent concurrent command execution in cron

Closes #47, Closes #49.

## Changes
### New files
- `WebFiori/Cli/Attributes/Group.php` — `#[Group("name")]` for help display grouping
- `WebFiori/Cli/Attributes/SingleInstance.php` — `#[SingleInstance]` for lock-based concurrency prevention
- `WebFiori/Cli/LockManager.php` — flock-based non-blocking exclusive locks with PID tracking

### Modified files
- `Command.php` — added `group` property, `getGroup()`/`setGroup()`, `resolveGroup()`, `resolveSingleInstance()`, integrated lock into `excCommand()` with try/finally
- `Runner.php` — calls `resolveGroup()` on register
- `HelpCommand.php` — grouped output when groups exist (alphabetical, ungrouped last)

### Resolution precedence (Group):
1. Explicit `setGroup()` (programmatic)
2. `#[Group]` attribute
3. Colon prefix in name (`db:migrate` → `db`)

### SingleInstance behavior:
- Lock acquired before `exec()`, released in `finally`
- OS releases flock on crash/SIGKILL
- Custom `lockPath` and `exitCode` supported

## How to Test / Verify
- `tests/WebFiori/Tests/Cli/LockManagerTest.php` (7 tests)
- `tests/WebFiori/Tests/Cli/CommandAttributesTest.php` (12 tests)

Run: `composer test`

## Breaking Changes and Migration Steps
None. Commands without attributes behave exactly as before.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed) — ADR-0025 updated to Accepted
- [x] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #47
Closes #49